### PR TITLE
Make screen readers announce the name automatically when it is generated.

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
 				</form>
 			</div>
 			<div class="span12">
-			<h2 id="result"></h2>
+			<h2 id="result" aria-live="assertive"></h2>
 			</div>
 		</div>
 


### PR DESCRIPTION
This commit adds a bit of invisible markup to the result heading that makes [screen readers](https://en.wikipedia.org/wiki/Screen_reader) announce the generated name automatically. A screen reader user can do just one thing at once, meaning that they can't watch the heading change its text while pressing the button at the same time. This isn't a critical addition by any means, but rather something that makes the experience more fun.