### PR TITLE
Fix issue #14 - add TypeScript declarations

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,11 @@
+declare module 'foswig' {
+    class Foswig {
+        constructor(order: number);
+
+        addWordsToChain(words: string[]): void;
+        addWordToChain(word: string): void;
+        generateWord(minLength?: number, maxLength?: number, allowDuplicates?: boolean, maxAttempts?: number): string;
+    }
+    
+    export = Foswig;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.1",
   "description": "A library that can generate legible pseudo random words based off an input dictionary using markov chains",
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "dependencies": {},
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
This merge request adds a TypeScript declarations file, fixing issue #14.

TypeScript projects can then import foswig via:
~~~typescript
import Foswig = require('foswig');
~~~