### PR TITLE
Fix issue #16 - hang when minLength is too high

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -142,12 +142,12 @@ module.exports.prototype.generateWord = function(minLength,maxLength,allowDuplic
 			nextNodeIndex = Math.floor(Math.random() * currentNode.neighbors.length);
 			currentNode = currentNode.neighbors[nextNodeIndex];
 		}
-		if ( (maxLength >= 0 && word.length > maxLength) || word.length < minLength ) {
+		if ( (maxLength >= 0 && word.length > maxLength) || word.length < minLength || (!allowDuplicates && isDuplicate(word,this.duplicates))) {
 			repeat = true;
 		}
 	}
 	// we don't want to output any exact replicas from the input dictionary
-	while (repeat || (!allowDuplicates && ++attempts < maxAttempts && isDuplicate(word,this.duplicates)));
+	while (repeat && ++attempts < maxAttempts);
 	if (attempts >= maxAttempts) {
 		throw new Error('Unable to generate a word with the given parameters after '+attempts+' attempts');
 	}

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -62,6 +62,13 @@ describe('Foswig',function() {
 				//console.log(word);
 			}
 		});
+
+		it('should throw when minLength is too high',function() {
+			var markov = new Foswig(2);
+			markov.addWordsToChain(dictionary);
+
+            expect(() => markov.generateWord(1000,1010,true)).to.throw();
+		});
 	});
 });
 


### PR DESCRIPTION
This fixes issue #16.  I moved the allowDuplicates check up, so that all of the conditions that should cause a repeat are in the same place.  Then the while loop condition is just `repeat && ++attempts < maxAttempts`.

Note: this may cause more "Unable to generate" errors.  Users may have been going past maxAttempts due to the code generating lots of words that were outside of the bounds (because those repeats were not counting as attempts).